### PR TITLE
generate demos using DemoCards

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,7 +2,11 @@
 Bokeh = "c4b4474d-016b-471b-b14f-576041b951ff"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DemoCards = "311a05b2-6137-4a5a-b473-18580a3d38b5"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[compat]
+DemoCards = "0.4.7"

--- a/docs/gallery/Basic/heatmap.jl
+++ b/docs/gallery/Basic/heatmap.jl
@@ -1,8 +1,11 @@
-# Heatmap (`Image`)
+# ---
+# title: Heatmap
+# id: demo_heatmap
+# description: "`Image`"
+# ---
 
-Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/image.html](https://docs.bokeh.org/en/latest/docs/gallery/image.html).
+# Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/image.html](https://docs.bokeh.org/en/latest/docs/gallery/image.html).
 
-```@example
 using Bokeh
 
 data = [
@@ -21,4 +24,3 @@ p.grids.grid_line_width = 0
 plot!(p, Image, image=[data], x=0, y=0, dw=10, dh=10, level="image", palette="Spectral11")
 
 p
-```

--- a/docs/gallery/Basic/image_rbga.jl
+++ b/docs/gallery/Basic/image_rbga.jl
@@ -1,8 +1,11 @@
-# Colours (`ImageRGBA`)
+# ---
+# title: Colours
+# id: demo_image_rgba
+# description: "`ImageRGBA`"
+# ---
 
-Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/image_rgba.html](https://docs.bokeh.org/en/latest/docs/gallery/image_rgba.html).
+# Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/image_rgba.html](https://docs.bokeh.org/en/latest/docs/gallery/image_rgba.html).
 
-```@example
 using Bokeh
 
 N = 20
@@ -29,4 +32,3 @@ p.ranges.range_padding = 0
 plot!(p, ImageRGBA, image=[img], x=0, y=0, dw=10, dh=10)
 
 p
-```

--- a/docs/gallery/Basic/latex.jl
+++ b/docs/gallery/Basic/latex.jl
@@ -1,16 +1,19 @@
-# Gaussian Distribution (`TeX`, `Div`, `column`, `Quad`, `Line`)
+# ---
+# title: Gaussian Distribution
+# id: demo_latex
+# description: "`TeX`, `Div`, `column`, `Quad`, `Line`"
+# ---
 
-Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/latex\_normal\_distribution.html](https://docs.bokeh.org/en/latest/docs/gallery/latex_normal_distribution.html).
+# Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/latex\_normal\_distribution.html](https://docs.bokeh.org/en/latest/docs/gallery/latex_normal_distribution.html).
 
-```@example
 using Bokeh, StatsBase
 
 N = 1000
 
-# Sample from a Gaussian distribution
+## Sample from a Gaussian distribution
 samples = randn(N)
 
-# Scale random data so that it has mean of 0 and standard deviation of 1
+## Scale random data so that it has mean of 0 and standard deviation of 1
 scaled = (samples .- mean(samples)) ./ std(samples)
 
 p = figure(
@@ -32,7 +35,7 @@ plot!(p, Quad,
     legend_label="$N random samples",
 )
 
-# Probability density function
+## Probability density function
 x = range(-3, 3, length=100)
 pdf = @. exp(-0.5 * x^2) / sqrt(2 * pi)
 plot!(p, Line,
@@ -79,4 +82,3 @@ div = Div(text=raw"""
     """)
 
 column(p, div)
-```

--- a/docs/gallery/Basic/les_mis.jl
+++ b/docs/gallery/Basic/les_mis.jl
@@ -1,8 +1,11 @@
-#  Les Misérables Co-occurrences (`Rect`, `tools`)
+# ---
+# title: Les Misérables Co-occurrences
+# id: demo_les_mis
+# description: "`Rect`, `tools`"
+# ---
 
-Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/les_mis.html](https://docs.bokeh.org/en/latest/docs/gallery/les_mis.html).
+# Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/les_mis.html](https://docs.bokeh.org/en/latest/docs/gallery/les_mis.html).
 
-```@example
 using Bokeh, Tables
 
 data = Bokeh.Data.les_mis(rowtable)
@@ -57,9 +60,8 @@ plot!(p, Rect,
     color="color",
     alpha="alpha",
     line_color=nothing,
-    # hover_color="colors", TODO
-    # hover_line_color="black", TODO
+    ## hover_color="colors", TODO
+    ## hover_line_color="black", TODO
 )
 
 p
-```

--- a/docs/gallery/Basic/lorenz.jl
+++ b/docs/gallery/Basic/lorenz.jl
@@ -1,10 +1,13 @@
-# Lorenz Attractor (`MultiLine`)
+# ---
+# title: Lorenz Attractor
+# id: demo_lorenz
+# description: "`MultiLine`"
+# ---
 
-Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/lorenz.html](https://docs.bokeh.org/en/latest/docs/gallery/lorenz.html).
+# Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/lorenz.html](https://docs.bokeh.org/en/latest/docs/gallery/lorenz.html).
 
-The `odeint` function is a very basic ODE solver, so the results are not quite the same.
+# The `odeint` function is a very basic ODE solver, so the results are not quite the same.
 
-```@example
 using Bokeh
 
 params = (sigma=10.0, rho=28.0, beta=8/3, theta=3π/4)
@@ -57,4 +60,3 @@ plot!(p, MultiLine,
 )
 
 p
-```

--- a/docs/gallery/Basic/mandelbrot.jl
+++ b/docs/gallery/Basic/mandelbrot.jl
@@ -1,8 +1,10 @@
-# Mandelbrot Set (`Image`)
+# ---
+# title: Mandelbrot Set
+# id: demo_mandelbrot
+# ---
 
-A classic visualisation of the Mandelbrot set.
+# A classic visualisation of the Mandelbrot set.
 
-```@example
 using Bokeh
 
 function mandelbrot(c::Complex, niters=100)
@@ -43,4 +45,3 @@ plot!(p, Image,
 )
 
 p
-```

--- a/docs/gallery/Basic/mpg.jl
+++ b/docs/gallery/Basic/mpg.jl
@@ -1,8 +1,11 @@
-# Auto MPG (`VBar`, `factor_cmap`, `tooltips`, nested factors)
+# ---
+# title: Auto MPG
+# id: demo_mpg
+# description: "`VBar`, `factor_cmap`, `tooltips`, nested factors"
+# ---
 
-Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/bar\_pandas\_groupby\_nested.html](https://docs.bokeh.org/en/latest/docs/gallery/bar_pandas_groupby_nested.html).
+# Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/bar\_pandas\_groupby\_nested.html](https://docs.bokeh.org/en/latest/docs/gallery/bar_pandas_groupby_nested.html).
 
-```@example
 using Bokeh, DataFrames, Statistics
 
 df = Bokeh.Data.autompg_clean(DataFrame)
@@ -41,4 +44,3 @@ p.x_axis.major_label_orientation = 1.2
 p.outline_line_color = nothing
 
 p
-```

--- a/docs/gallery/Basic/penguins.jl
+++ b/docs/gallery/Basic/penguins.jl
@@ -1,8 +1,11 @@
-# Penguins (`Scatter`, `factor_mark`, `factor_cmap`)
+# ---
+# title: Penguins
+# id: demo_penguins
+# description: "`Scatter`, `factor_mark`, `factor_cmap`"
+# ---
 
-Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/marker_map.html](https://docs.bokeh.org/en/latest/docs/gallery/marker_map.html).
+# Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/marker_map.html](https://docs.bokeh.org/en/latest/docs/gallery/marker_map.html).
 
-```@example
 using Bokeh, Tables
 
 data = Bokeh.Data.penguins(columntable)
@@ -29,4 +32,3 @@ plot!(p, Scatter,
 )
 
 p
-```

--- a/docs/gallery/Basic/vbar.jl
+++ b/docs/gallery/Basic/vbar.jl
@@ -1,8 +1,11 @@
-# Bar Charts (`VBar`, `factor_cmap`)
+# ---
+# title: Bar Charts
+# id: demo_vbar
+# description: "`VBar`, `factor_cmap`"
+# ---
 
-Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/bar_colormapped.html](https://docs.bokeh.org/en/latest/docs/gallery/bar_colormapped.html).
+# Reproduces the plot from [https://docs.bokeh.org/en/latest/docs/gallery/bar_colormapped.html](https://docs.bokeh.org/en/latest/docs/gallery/bar_colormapped.html).
 
-```@example
 using Bokeh
 
 data = (
@@ -34,4 +37,3 @@ p.legend.orientation = "horizontal"
 p.legend.location = "top_center"
 
 p
-```

--- a/docs/gallery/config.json
+++ b/docs/gallery/config.json
@@ -1,0 +1,6 @@
+{
+    "theme": "bulmagrid",
+    "properties": {
+        "notebook": false
+    }
+}

--- a/docs/gallery/index.md
+++ b/docs/gallery/index.md
@@ -1,0 +1,5 @@
+# Gallery
+
+This page contains a lot of Bokeh examples for you to explore, feel free to add more!
+
+{{{democards}}}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,9 @@
 using Documenter, Bokeh
 
+using DemoCards
+
+gallery, gallery_cb, gallery_assets = makedemos("gallery")
+
 # hack presumably because I didn't generate markdown properly from the spec
 # TODO: fix it
 Base.convert(::Type{Vector{T}}, x::T) where {T<:Documenter.Utilities.Markdown2.MarkdownNode} = T[x]
@@ -47,9 +51,15 @@ open("docs/src/models.md", "w") do io
     end
 end
 
+format = Documenter.HTML(
+    edit_link = "master",
+    prettyurls = get(ENV, "CI", nothing) == "true",
+    assets = Any[gallery_assets],
+)
 makedocs(
     sitename = "Bokeh",
     modules = [Bokeh],
+    format = format,
     pages = [
         "Home" => "index.md",
         "guide.md",
@@ -59,17 +69,7 @@ makedocs(
             "data.md",
             "models.md",
         ],
-        "Gallery" => [
-            "gallery/mandelbrot.md",
-            "gallery/penguins.md",
-            "gallery/vbar.md",
-            "gallery/lorenz.md",
-            "gallery/image.md",
-            "gallery/image_rgba.md",
-            "gallery/latex.md",
-            "gallery/les_mis.md",
-            "gallery/mpg.md",
-        ],
+        gallery
     ],
     strict = [
         :autodocs_block,
@@ -86,6 +86,8 @@ makedocs(
         :setup_block,
     ]
 )
+
+gallery_cb() # redirect URL and clean up tmp files
 
 deploydocs(
     repo = "github.com/cjdoris/Bokeh.jl.git",


### PR DESCRIPTION
This tries to build something like http://juliaplots.org/AlgebraOfGraphics.jl/dev/gallery/ using DemoCards.

This uses the [Literate](https://github.com/fredrikekre/Literate.jl) syntax:

- leading `#` means markdown
- leading `##` means Julia comment

Todo:

- [ ] I don't know how to export a PNG file to get the cover image #5
- [ ] I put all demos into one section `Basic`, you might want to split them down into multiple folders