### PR TITLE
support browser open on WSL

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -10,7 +10,7 @@ function Base.display(d::BokehDisplay, m::MIME"text/html", x::Document)
         if first(cmd) == "wslview"
             # It's a bit tricky to resolve WSL path correctly so as a workaround just cd into it
             # https://github.com/fish-shell/fish-shell/issues/6338
-            run(Cmd(`$cmd plot.html`, dir=setting(:tempdir)))
+            run(Cmd(`$cmd $(basename(path))`, dir=setting(:tempdir)))
         else
             run(`$cmd $(path)`)
         end

--- a/src/display.jl
+++ b/src/display.jl
@@ -6,8 +6,15 @@ function Base.display(d::BokehDisplay, m::MIME"text/html", x::Document)
         open(path, "w") do io
             write(io, doc_standalone_html(x; bundle=bundle()))
         end
-        cd(setting(:tempdir)) do
-            run(`$(setting(:browser_cmd)) plot.html`)
+        cmd = setting(:browser_cmd)
+        if first(cmd) == "wslview"
+            # It's a bit tricky to resolve WSL path correctly so as a workaround just cd into it
+            # https://github.com/fish-shell/fish-shell/issues/6338
+            cd(setting(:tempdir)) do
+                run(`$cmd plot.html`)
+            end
+        else
+            run(`$cmd $(path)`)
         end
         return
     else

--- a/src/display.jl
+++ b/src/display.jl
@@ -6,7 +6,15 @@ function Base.display(d::BokehDisplay, m::MIME"text/html", x::Document)
         open(path, "w") do io
             write(io, doc_standalone_html(x; bundle=bundle()))
         end
-        run(`$(setting(:browser_cmd)) $(path)`)
+        if is_wsl()
+            # It's a bit tricky to resolve WSL path correctly so as a workaround just cd into it
+            # https://github.com/fish-shell/fish-shell/issues/6338
+            cd(setting(:tempdir)) do
+                run(`$(setting(:browser_cmd)) plot.html`)
+            end
+        else
+            run(`$(setting(:browser_cmd)) $(path)`)
+        end
         return
     else
         throw(MethodError(display, (d, m, x)))

--- a/src/display.jl
+++ b/src/display.jl
@@ -10,9 +10,7 @@ function Base.display(d::BokehDisplay, m::MIME"text/html", x::Document)
         if first(cmd) == "wslview"
             # It's a bit tricky to resolve WSL path correctly so as a workaround just cd into it
             # https://github.com/fish-shell/fish-shell/issues/6338
-            cd(setting(:tempdir)) do
-                run(`$cmd plot.html`)
-            end
+            run(Cmd(`$cmd plot.html`, dir=setting(:tempdir)))
         else
             run(`$cmd $(path)`)
         end

--- a/src/display.jl
+++ b/src/display.jl
@@ -10,7 +10,7 @@ function Base.display(d::BokehDisplay, m::MIME"text/html", x::Document)
         if first(cmd) == "wslview"
             # It's a bit tricky to resolve WSL path correctly so as a workaround just cd into it
             # https://github.com/fish-shell/fish-shell/issues/6338
-            run(Cmd(`$cmd $(basename(path))`, dir=setting(:tempdir)))
+            run(Cmd(`$cmd $(basename(path))`, dir=dirname(path)))
         else
             run(`$cmd $(path)`)
         end

--- a/src/display.jl
+++ b/src/display.jl
@@ -6,14 +6,8 @@ function Base.display(d::BokehDisplay, m::MIME"text/html", x::Document)
         open(path, "w") do io
             write(io, doc_standalone_html(x; bundle=bundle()))
         end
-        if is_wsl()
-            # It's a bit tricky to resolve WSL path correctly so as a workaround just cd into it
-            # https://github.com/fish-shell/fish-shell/issues/6338
-            cd(setting(:tempdir)) do
-                run(`$(setting(:browser_cmd)) plot.html`)
-            end
-        else
-            run(`$(setting(:browser_cmd)) $(path)`)
+        cd(setting(:tempdir)) do
+            run(`$(setting(:browser_cmd)) plot.html`)
         end
         return
     else

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -113,20 +113,10 @@ function _get_browser_cmd()
     end
 end
 
-const _IS_WSL = Array{Union{Nothing,Bool},0}(undef)
 function is_wsl()
-    if !isnothing(_IS_WSL[])
-        return _IS_WSL[]
-    end
-    Sys.islinux() || return false
-    msg = _capture_stdout_run(`grep WSL /proc/version`)
-    _IS_WSL[] = !isempty(msg)
-    return _IS_WSL[]
-end
-function _capture_stdout_run(cmd)
-    io = IOBuffer()
-    run(pipeline(cmd, stdout=io))
-    return String(take!(io))
+    Sys.islinux() &&
+        isfile("/proc/version") &&
+        occursin("microsoft", lowercase(read("/proc/version", String)))
 end
 
 function bundle()


### PR DESCRIPTION
This works locally on Windows11 WSL

```console
PS C:\Users\jc> wsl --status
Default Distribution: Ubuntu-20.04
Default Version: 2

Windows Subsystem for Linux was last updated on 2022/3/26
WSL automatic updates are on.

Kernel version: 5.10.102.1
```

```console
➜ cat /proc/version                                                                                                                                                                     (base) 
Linux version 5.10.102.1-microsoft-standard-WSL2 (oe-user@oe-host) (x86_64-msft-linux-gcc (GCC) 9.3.0, GNU ld (GNU Binutils) 2.34.0.20200220) #1 SMP Wed Mar 2 00:30:59 UTC 2022
➜ fish --version                                                                                                                                                                        (base) 
fish, version 3.3.1
```

```julia
julia> versioninfo()
Julia Version 1.7.2
Commit bf53498635 (2022-02-06 15:21 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: 12th Gen Intel(R) Core(TM) i9-12900K
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, goldmont)
```